### PR TITLE
feat: Integrate new player and balloon graphics

### DIFF
--- a/mathgame.html
+++ b/mathgame.html
@@ -42,15 +42,108 @@
     let player={x:canvas.width/2-20,y:canvas.height-60,size:40,speed:6};
     let balloons=[],currentQuestion=null,score=0,lives=3,gameInterval=null,spawnInterval=null,isRunning=false;
     const BALLOON_RADIUS=28;
+
+    // Preload player image
+    const playerImage = new Image();
+    playerImage.src = 'assets/images/player_character.png';
+    // It's good practice to ensure the image is loaded before trying to draw it.
+    // For simplicity, we'll assume it loads quickly for local assets.
+    // Optionally, add playerImage.onload = () => { /* game start logic or flag */ };
+
+    const balloonImagePaths = [
+      'assets/images/balloon_rainbow.svg',
+      'assets/images/balloon_star.svg',
+      'assets/images/balloon_happy_face.svg'
+    ];
+    const balloonImages = [];
+    balloonImagePaths.forEach(path => {
+      const img = new Image();
+      img.src = path;
+      balloonImages.push(img);
+    });
+
     const AudioContext=window.AudioContext||window.webkitAudioContext;const audioCtx=new AudioContext();
     function startBackgroundMusic(){const notes=[261.63,293.66,329.63,349.23];let index=0;function playNext(){if(!isRunning)return;const now=audioCtx.currentTime;const osc=audioCtx.createOscillator();const gain=audioCtx.createGain();osc.type='sine';osc.frequency.setValueAtTime(notes[index],now);gain.gain.setValueAtTime(0.05,now);osc.connect(gain);gain.connect(audioCtx.destination);osc.start(now);osc.stop(now+0.3);index=(index+1)%notes.length;setTimeout(playNext,400);}playNext();}
     function playPopSound(){const now=audioCtx.currentTime;const osc1=audioCtx.createOscillator(),osc2=audioCtx.createOscillator(),gain=audioCtx.createGain();osc1.type='triangle';osc2.type='triangle';osc1.frequency.setValueAtTime(880,now);osc2.frequency.setValueAtTime(660,now);gain.gain.setValueAtTime(0.12,now);osc1.connect(gain);osc2.connect(gain);gain.connect(audioCtx.destination);osc1.start(now);osc2.start(now);osc1.frequency.linearRampToValueAtTime(440,now+0.15);osc2.frequency.linearRampToValueAtTime(330,now+0.15);osc1.stop(now+0.15);osc2.stop(now+0.15);}
     function playFailSound(){const now=audioCtx.currentTime;const osc=audioCtx.createOscillator(),gain=audioCtx.createGain();osc.type='sawtooth';osc.frequency.setValueAtTime(200,now);gain.gain.setValueAtTime(0.15,now);osc.connect(gain);gain.connect(audioCtx.destination);osc.start(now);osc.frequency.exponentialRampToValueAtTime(50,now+0.4);gain.gain.linearRampToValueAtTime(0,now+0.4);osc.stop(now+0.4);}
     function generateQuestion(){const a=Math.floor(Math.random()*9)+1,b=Math.floor(Math.random()*9)+1,ops=['+','-','*'],op=ops[Math.floor(Math.random()*ops.length)];let ans;if(op==='+')ans=a+b;if(op==='-')ans=a-b;if(op==='*')ans=a*b;currentQuestion={text:`${a} ${op} ${b} = ?`,answer:ans};questionEl.textContent=currentQuestion.text;}
-    function spawnBalloons(){const correct=currentQuestion.answer;let choices=[correct];while(choices.length<4){let fake=correct+(Math.floor(Math.random()*9)-4);if(fake!==correct&&fake>=0&&!choices.includes(fake))choices.push(fake);}shuffleArray(choices);balloons=choices.map((val,idx)=>{const xPos=idx*(canvas.width/4)+(canvas.width/8)-BALLOON_RADIUS;return{x:xPos,y:-(BALLOON_RADIUS*2+Math.random()*80),val:val,color:`hsl(${Math.random()*360},80%,65%)`,speed:1+Math.random()*1.5,floatOffset:Math.random()*Math.PI*2};});}
+    function spawnBalloons(){
+      const correct=currentQuestion.answer;
+      let choices=[correct];
+      while(choices.length<4){
+        let fake=correct+(Math.floor(Math.random()*9)-4);
+        if(fake!==correct&&fake>=0&&!choices.includes(fake)) choices.push(fake);
+      }
+      shuffleArray(choices);
+      balloons=choices.map((val,idx)=>{
+        const xPos=idx*(canvas.width/4)+(canvas.width/8)-BALLOON_RADIUS;
+        const randomImage = balloonImages[Math.floor(Math.random() * balloonImages.length)];
+        return {
+          x:xPos,
+          y:-(BALLOON_RADIUS*2+Math.random()*80),
+          val:val,
+          image: randomImage, // Assign random image
+          speed:1+Math.random()*1.5,
+          floatOffset:Math.random()*Math.PI*2
+        };
+      });
+    }
     function shuffleArray(arr){for(let i=arr.length-1;i>0;i--){const j=Math.floor(Math.random()*(i+1));[arr[i],arr[j]]=[arr[j],arr[i]];}}
-    function drawPlayer(){const x=player.x+player.size/2,y=player.y+player.size/2;ctx.save();ctx.translate(x,y);ctx.fillStyle='#ff69b4';ctx.beginPath();for(let i=0;i<5;i++){ctx.lineTo(Math.cos((18+i*72)/180*Math.PI)*player.size/2,-Math.sin((18+i*72)/180*Math.PI)*player.size/2);ctx.lineTo(Math.cos((54+i*72)/180*Math.PI)*player.size/4,-Math.sin((54+i*72)/180*Math.PI)*player.size/4);}ctx.closePath();ctx.fill();ctx.restore();}
-    function drawBalloons(){ctx.font='18px Arial';balloons.forEach(balloon=>{const sway=Math.sin((Date.now()/500)+balloon.floatOffset)*8;const bx=balloon.x+sway,by=balloon.y;ctx.beginPath();ctx.arc(bx+BALLOON_RADIUS+3,by+BALLOON_RADIUS+3,BALLOON_RADIUS,0,Math.PI*2);ctx.fillStyle='rgba(0,0,0,0.1)';ctx.fill();ctx.beginPath();ctx.arc(bx+BALLOON_RADIUS,by+BALLOON_RADIUS,BALLOON_RADIUS,0,Math.PI*2);ctx.fillStyle=balloon.color;ctx.fill();ctx.beginPath();ctx.arc(bx+BALLOON_RADIUS-8,by+BALLOON_RADIUS-12,BALLOON_RADIUS/4,0,Math.PI*2);ctx.fillStyle='rgba(255,255,255,0.7)';ctx.fill();ctx.strokeStyle='#888';ctx.lineWidth=2;ctx.beginPath();ctx.moveTo(bx+BALLOON_RADIUS,by+BALLOON_RADIUS*2);ctx.lineTo(bx+BALLOON_RADIUS,by+BALLOON_RADIUS*2+20);ctx.stroke();ctx.fillStyle='#ffffff';ctx.textAlign='center';ctx.fillText(balloon.val,bx+BALLOON_RADIUS,by+BALLOON_RADIUS+6);});}
+    function drawPlayer(){
+      if (playerImage.complete) { // Check if image is loaded
+        ctx.drawImage(playerImage, player.x, player.y, player.size, player.size);
+      } else {
+        // Optional: Draw a fallback shape if image isn't loaded yet
+        const x=player.x+player.size/2,y=player.y+player.size/2;ctx.save();ctx.translate(x,y);ctx.fillStyle='#ff69b4';ctx.beginPath();for(let i=0;i<5;i++){ctx.lineTo(Math.cos((18+i*72)/180*Math.PI)*player.size/2,-Math.sin((18+i*72)/180*Math.PI)*player.size/2);ctx.lineTo(Math.cos((54+i*72)/180*Math.PI)*player.size/4,-Math.sin((54+i*72)/180*Math.PI)*player.size/4);}ctx.closePath();ctx.fill();ctx.restore();
+      }
+    }
+    function drawBalloons(){
+      ctx.font='bold 18px Arial'; // Ensure text is bold for better visibility
+      balloons.forEach(balloon=>{
+        const sway=Math.sin((Date.now()/500)+balloon.floatOffset)*8;
+        const bx=balloon.x+sway; // Balloon's X position including sway
+        const by=balloon.y;     // Balloon's Y position
+
+        // Optional: Draw shadow (can be kept or removed)
+        ctx.beginPath();
+        ctx.arc(bx+BALLOON_RADIUS+3,by+BALLOON_RADIUS+3,BALLOON_RADIUS,0,Math.PI*2);
+        ctx.fillStyle='rgba(0,0,0,0.1)';
+        ctx.fill();
+
+        if (balloon.image && balloon.image.complete) {
+          // Draw the balloon image
+          // The image is drawn from its top-left corner (bx, by)
+          // Width and height are BALLOON_RADIUS * 2
+          ctx.drawImage(balloon.image, bx, by, BALLOON_RADIUS * 2, BALLOON_RADIUS * 2);
+        } else {
+          // Fallback to old drawing logic if image not loaded or not set
+          ctx.beginPath();
+          ctx.arc(bx + BALLOON_RADIUS, by + BALLOON_RADIUS, BALLOON_RADIUS, 0, Math.PI * 2);
+          ctx.fillStyle = balloon.color || 'gray'; // Use balloon.color or a default
+          ctx.fill();
+           // Fallback highlight if needed (original highlight was on colored circle)
+          ctx.beginPath();
+          ctx.arc(bx+BALLOON_RADIUS-8,by+BALLOON_RADIUS-12,BALLOON_RADIUS/4,0,Math.PI*2);
+          ctx.fillStyle='rgba(255,255,255,0.7)';
+          ctx.fill();
+        }
+
+        // Draw the balloon string (can be kept or modified)
+        ctx.strokeStyle='#888';
+        ctx.lineWidth=2;
+        ctx.beginPath();
+        // String starts from the center bottom of the image
+        ctx.moveTo(bx+BALLOON_RADIUS, by + BALLOON_RADIUS * 2);
+        ctx.lineTo(bx+BALLOON_RADIUS, by + BALLOON_RADIUS * 2 + 20); // Length of 20
+        ctx.stroke();
+
+        // Draw the value text
+        ctx.fillStyle='#000000'; // Black color for text for better contrast
+        ctx.textAlign='center';
+        // Position text in the center of the image
+        ctx.fillText(balloon.val, bx + BALLOON_RADIUS, by + BALLOON_RADIUS + 6);
+      });
+    }
     function update(){ctx.clearRect(0,0,canvas.width,canvas.height);drawBalloons();drawPlayer();balloons.forEach(balloon=>{balloon.y+=balloon.speed;if(balloon.y>canvas.height){if(balloon.val===currentQuestion.answer)loseLife();removeBalloon(balloon);}});balloons.forEach(balloon=>{const sway=Math.sin((Date.now()/500)+balloon.floatOffset)*8;const bx=balloon.x+sway,by=balloon.y;if(player.x<bx+BALLOON_RADIUS*2&&player.x+player.size>bx&&player.y<by+BALLOON_RADIUS*2&&player.y+player.size>by){if(balloon.val===currentQuestion.answer){score+=10;playPopSound();}else{loseLife();playFailSound();}updateInfo();removeBalloon(balloon);}});}  
     function removeBalloon(balloon){const idx=balloons.indexOf(balloon);if(idx>-1)balloons.splice(idx,1);if(balloons.length===0)prepareNextRound();}
     function prepareNextRound(){generateQuestion();spawnBalloons();updateInfo();}


### PR DESCRIPTION
Replaces the previous canvas-drawn player (star shape) and balloons (colored circles) with image-based graphics.

- Player character is now loaded from `assets/images/player_character.png`.
- Balloons now randomly use one of several predefined skins (e.g., `assets/images/balloon_rainbow.svg`, `assets/images/balloon_star.svg`) also loaded from the `assets/images/` directory.
- Includes fallback drawing logic in case images are not yet loaded, to prevent errors.
- The `assets/images/` directory is introduced as the location for these new image assets.
- Balloon values remain displayed over the new graphics.

This change addresses the first part of the '美术与界面' section of the overall game enhancement issue.