### PR TITLE
Fix: Resolve "exports is not defined" error

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es6",
-    "module": "commonjs",
+    "module": "es2020",
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,


### PR DESCRIPTION
Changed TypeScript compiler options to output ES modules (es2020) instead of CommonJS. This allows the `gameController.js` and other generated JavaScript files to be loaded directly in your browser without causing a ReferenceError for `exports`.

- Modified `tsconfig.json` to set `compilerOptions.module` to `es2020`.
- Ensured `index.html` loads the main script with `type="module"`.
- Rebuilt the project with the new settings.