### PR TITLE
I've fixed the Jest import errors and rebuilt the `dist` directory.

### DIFF
--- a/src/components/balloon.ts
+++ b/src/components/balloon.ts
@@ -1,5 +1,5 @@
-import { canvas, ctx } from '../utils/domElements.js';
-import { shuffleArray } from '../utils/helpers.js';
+import { canvas, ctx } from '../utils/domElements';
+import { shuffleArray } from '../utils/helpers';
 
 // Type definitions
 export interface Question { // Define it locally or import from a shared types file if created

--- a/src/core/player.ts
+++ b/src/core/player.ts
@@ -1,4 +1,4 @@
-import { canvas, ctx } from '../utils/domElements.js';
+import { canvas, ctx } from '../utils/domElements';
 
 // Type definitions
 export interface Player {
@@ -13,10 +13,15 @@ export const playerImage = new Image();
 playerImage.src = 'assets/images/player_character.svg'; // Ensure these assets are available
 
 export function drawPlayer(player: Player | null): void {
+  console.log("drawPlayer called with:", player);
   if (!ctx || !player) return;
+
+  console.log("playerImage state:", playerImage.src, playerImage.complete, playerImage.naturalWidth, playerImage.naturalHeight);
   if (playerImage.complete && playerImage.naturalHeight !== 0) {
+    console.log("Drawing player image");
     ctx.drawImage(playerImage, player.x, player.y, player.size, player.size);
   } else {
+    console.log("Drawing fallback player shape");
     const x: number = player.x + player.size / 2;
     const y: number = player.y + player.size / 2;
     ctx.save();

--- a/src/core/questions.ts
+++ b/src/core/questions.ts
@@ -1,4 +1,4 @@
-import { questionEl } from '../utils/domElements.js';
+import { questionEl } from '../utils/domElements';
 
 export interface Question {
   text: string;

--- a/src/gameController.ts
+++ b/src/gameController.ts
@@ -1,8 +1,8 @@
-import { canvas, ctx, scoreEl, livesEl, startBtn, overlay, messageTitle, messageContent, restartBtn } from './utils/domElements.js';
-import { Player, drawPlayer } from './core/player.js';
-import { Balloon, BALLOON_RADIUS, spawnBalloons, drawBalloons } from './components/balloon.js';
-import { Question, generateQuestion } from './core/questions.js';
-import { audioCtx, startBackgroundMusic, playPopSound, playFailSound } from './core/audio.js';
+import { canvas, ctx, scoreEl, livesEl, startBtn, overlay, messageTitle, messageContent, restartBtn } from './utils/domElements';
+import { Player, drawPlayer } from './core/player';
+import { Balloon, BALLOON_RADIUS, spawnBalloons, drawBalloons } from './components/balloon';
+import { Question, generateQuestion } from './core/questions';
+import { audioCtx, startBackgroundMusic, playPopSound, playFailSound } from './core/audio';
 
 // Game State Variables
 let player: Player | null = null;


### PR DESCRIPTION
I modified the TypeScript import paths in several files to remove '.js' extensions. This resolved the 'Cannot find module' errors you were seeing when running tests with Jest and ts-jest. All tests are now passing.

Here are the files I updated:
- src/core/questions.ts
- src/core/player.ts
- src/components/balloon.ts
- src/gameController.ts

I also ran 'npm run build' to update the `dist/` directory with these changes and include the latest console logs for debugging the player display.